### PR TITLE
Run GitHub Actions only once per PR

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,10 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master]
+    branches:
+      - master
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [master]
   schedule:
     - cron: '0 1 * * 6'
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,6 +1,10 @@
 name: Check and test imglocate
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,6 +1,10 @@
 name: Semgrep
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   semgrep:


### PR DESCRIPTION
By using both `push:` and `pull_request:` without limiting branches for the `push:` events the GitHub Actions workflows are run twice.

Avoid that by properly limiting `push:` to only the `master` branch.
